### PR TITLE
Differentiate stopping from disabling

### DIFF
--- a/sites/en/pages/ansible-disable-apt-get.txt
+++ b/sites/en/pages/ansible-disable-apt-get.txt
@@ -17,7 +17,7 @@ and the Ansible process that tries to install modules
 - name: Stop services
   service:
     name: "{{ item }}"
-    enabled: no
+    state: stopped
   with_items:
     - apt-daily
     - apt-daily.timer


### PR DESCRIPTION
In the "Stop services" block, it should be `state: stopped` rather than `enabled: no`, right? Otherwise the two blocks are exactly the same. For that matter, is it even necessary to have two blocks? I would have hoped that `enabled: no` also implies stopping the service.